### PR TITLE
Update builder image to 1.15 to fix build failure

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.13 AS builder
+FROM openshift/origin-release:golang-1.15 AS builder
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
 ENV BUILDTAGS include_oss include_gcs
 ARG GOOS=linux


### PR DESCRIPTION
1.13 is too old with the updates we added to catch the branch up. 1.16 is also too new and fails with go mod errors so we either need additional fixes we haven't pulled in or to investigate and fix it ourselves to go beyond 1.15