### PR TITLE
Remove hardcoded GOARCH from Dockerfile.ubi

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,9 +1,6 @@
 FROM openshift/origin-release:golang-1.13 AS builder
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
 ENV BUILDTAGS include_oss include_gcs
-ARG GOOS=linux
-ARG GOARCH=amd64
-ARG GOARM=6
 ARG VERSION
 ARG REVISION
 RUN yum -y install make git file


### PR DESCRIPTION
This is needed for proper building on other architectures.

/cc @jmontleon