### PR TITLE
OADP-390 CVE-2022-21698 disable prometheus usage

### DIFF
--- a/cmd/registry/config-dev.yml
+++ b/cmd/registry/config-dev.yml
@@ -33,7 +33,7 @@ http:
     debug:
         addr: :5001
         prometheus:
-            enabled: true
+            enabled: false
             path: /metrics
     headers:
         X-Content-Type-Options: [nosniff]


### PR DESCRIPTION
https://issues.redhat.com/browse/OADP-390
See verification in attached issue.
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>