### PR TITLE
UPSTREAM: docker/distribution: 3296: allow pointing to an AWS config …

### DIFF
--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -25,19 +25,23 @@ var s3DriverConstructor func(rootDirectory, storageClass string) (*Driver, error
 var skipS3 func() string
 
 func init() {
-	accessKey := os.Getenv("AWS_ACCESS_KEY")
-	secretKey := os.Getenv("AWS_SECRET_KEY")
-	bucket := os.Getenv("S3_BUCKET")
-	encrypt := os.Getenv("S3_ENCRYPT")
-	keyID := os.Getenv("S3_KEY_ID")
-	secure := os.Getenv("S3_SECURE")
-	skipVerify := os.Getenv("S3_SKIP_VERIFY")
-	v4Auth := os.Getenv("S3_V4_AUTH")
-	region := os.Getenv("AWS_REGION")
-	objectACL := os.Getenv("S3_OBJECT_ACL")
-	root, err := ioutil.TempDir("", "driver-")
-	regionEndpoint := os.Getenv("REGION_ENDPOINT")
-	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
+	var (
+		accessKey             = os.Getenv("AWS_ACCESS_KEY")
+		secretKey             = os.Getenv("AWS_SECRET_KEY")
+		bucket                = os.Getenv("S3_BUCKET")
+		encrypt               = os.Getenv("S3_ENCRYPT")
+		keyID                 = os.Getenv("S3_KEY_ID")
+		secure                = os.Getenv("S3_SECURE")
+		skipVerify            = os.Getenv("S3_SKIP_VERIFY")
+		v4Auth                = os.Getenv("S3_V4_AUTH")
+		region                = os.Getenv("AWS_REGION")
+		objectACL             = os.Getenv("S3_OBJECT_ACL")
+		regionEndpoint        = os.Getenv("REGION_ENDPOINT")
+		sessionToken          = os.Getenv("AWS_SESSION_TOKEN")
+		credentialsConfigPath = os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	)
+
+	root, err := os.MkdirTemp("", "driver-")
 	if err != nil {
 		panic(err)
 	}
@@ -96,6 +100,7 @@ func init() {
 			driverName + "-test",
 			objectACL,
 			sessionToken,
+			credentialsConfigPath,
 		}
 
 		return New(parameters)


### PR DESCRIPTION
…file as a parameter for the s3 driver

Recognize a new parameter when setting up the AWS client so that a generic AWS config file can be used instead of having to specify AWS access and secret keys.

This should allow someone to use different authentication methods beyond just access key, secret key (and optionally session token).

Using the current supported auth methods a valid file would look like:
```
[default]
aws_access_key_id = AKMYAWSACCCESSKEYID
aws_secret_access_key = myawssecretaccesskey
```

But you can also specify alternative auth methods:
```
[default]
role_arn = arn:aws:iam:ACCOUNT_NUM:role/ROLE_NAME
web_identity_token_file = /path/to/token
```