### PR TITLE
cherry-pick UPSTREAM: docker/distribution: 3296: allow pointing to an AWS config …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,15 +41,12 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.24 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.18 // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
-	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b // indirect
 	github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
@@ -65,7 +62,6 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/kr/text v0.1.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/konveyor/distribution
+module github.com/konveyor/distribution/v3
 
 go 1.18
 

--- a/go.sum
+++ b/go.sum
@@ -72,7 +72,6 @@ github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSY
 github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/autorest/to v0.4.0 h1:oXVqrxakqqV1UZdSazDOPOLvOIz+XA683u8EctwboHk=
-github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcPR4o9jEImooCeWJcYV/zLE=
 github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+ZtXWSmf4Tg=
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
@@ -96,7 +95,6 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
-github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=
@@ -137,7 +135,6 @@ github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8l
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
-github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=
@@ -313,7 +310,6 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f h1:2+myh5ml7lgEU/51gbeLHfKGNfgEQQIWrlbdaOsidbQ=
-github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -27,27 +26,34 @@ import (
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) { check.TestingT(t) }
 
-var s3DriverConstructor func(rootDirectory, storageClass string) (*Driver, error)
-var skipS3 func() string
+var (
+	s3DriverConstructor func(rootDirectory, storageClass string) (*Driver, error)
+	skipS3              func() string
+)
 
 func init() {
-	accessKey := os.Getenv("AWS_ACCESS_KEY")
-	secretKey := os.Getenv("AWS_SECRET_KEY")
-	bucket := os.Getenv("S3_BUCKET")
-	encrypt := os.Getenv("S3_ENCRYPT")
-	keyID := os.Getenv("S3_KEY_ID")
-	secure := os.Getenv("S3_SECURE")
-	skipVerify := os.Getenv("S3_SKIP_VERIFY")
-	v4Auth := os.Getenv("S3_V4_AUTH")
-	region := os.Getenv("AWS_REGION")
-	objectACL := os.Getenv("S3_OBJECT_ACL")
-	root, err := ioutil.TempDir("", "driver-")
-	regionEndpoint := os.Getenv("REGION_ENDPOINT")
-	forcePathStyle := os.Getenv("AWS_S3_FORCE_PATH_STYLE")
-	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
-	useDualStack := os.Getenv("S3_USE_DUALSTACK")
-	combineSmallPart := os.Getenv("MULTIPART_COMBINE_SMALL_PART")
-	accelerate := os.Getenv("S3_ACCELERATE")
+	var (
+		accessKey             = os.Getenv("AWS_ACCESS_KEY")
+		secretKey             = os.Getenv("AWS_SECRET_KEY")
+		bucket                = os.Getenv("S3_BUCKET")
+		encrypt               = os.Getenv("S3_ENCRYPT")
+		keyID                 = os.Getenv("S3_KEY_ID")
+		secure                = os.Getenv("S3_SECURE")
+		skipVerify            = os.Getenv("S3_SKIP_VERIFY")
+		v4Auth                = os.Getenv("S3_V4_AUTH")
+		region                = os.Getenv("AWS_REGION")
+		objectACL             = os.Getenv("S3_OBJECT_ACL")
+		regionEndpoint        = os.Getenv("REGION_ENDPOINT")
+		forcePathStyle        = os.Getenv("AWS_S3_FORCE_PATH_STYLE")
+		sessionToken          = os.Getenv("AWS_SESSION_TOKEN")
+		useDualStack          = os.Getenv("S3_USE_DUALSTACK")
+		combineSmallPart      = os.Getenv("MULTIPART_COMBINE_SMALL_PART")
+		accelerate            = os.Getenv("S3_ACCELERATE")
+		virtualHostedStyle    = os.Getenv("S3_VIRTUAL_HOSTED_STYLE")
+		credentialsConfigPath = os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	)
+
+	root, err := os.MkdirTemp("", "driver-")
 	if err != nil {
 		panic(err)
 	}
@@ -114,6 +120,14 @@ func init() {
 			}
 		}
 
+		virtualHostedStyleBool := true
+		if virtualHostedStyle != "" {
+			virtualHostedStyleBool, err = strconv.ParseBool(virtualHostedStyle)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		parameters := DriverParameters{
 			accessKey,
 			secretKey,
@@ -138,6 +152,8 @@ func init() {
 			sessionToken,
 			useDualStackBool,
 			accelerateBool,
+			virtualHostedStyleBool,
+			credentialsConfigPath,
 		}
 
 		return New(parameters)
@@ -161,12 +177,7 @@ func TestEmptyRootList(t *testing.T) {
 		t.Skip(skipS3())
 	}
 
-	validRoot, err := ioutil.TempDir("", "driver-")
-	if err != nil {
-		t.Fatalf("unexpected error creating temporary directory: %v", err)
-	}
-	defer os.Remove(validRoot)
-
+	validRoot := t.TempDir()
 	rootedDriver, err := s3DriverConstructor(validRoot, s3.StorageClassStandard)
 	if err != nil {
 		t.Fatalf("unexpected error creating rooted driver: %v", err)
@@ -199,9 +210,9 @@ func TestEmptyRootList(t *testing.T) {
 	}
 
 	keys, _ = slashRootDriver.List(ctx, "/")
-	for _, path := range keys {
-		if !storagedriver.PathRegexp.MatchString(path) {
-			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)
+	for _, p := range keys {
+		if !storagedriver.PathRegexp.MatchString(p) {
+			t.Fatalf("unexpected string in path: %q != %q", p, storagedriver.PathRegexp)
 		}
 	}
 }
@@ -244,12 +255,7 @@ func TestStorageClass(t *testing.T) {
 		t.Skip(skipS3())
 	}
 
-	rootDir, err := ioutil.TempDir("", "driver-")
-	if err != nil {
-		t.Fatalf("unexpected error creating temporary directory: %v", err)
-	}
-	defer os.Remove(rootDir)
-
+	rootDir := t.TempDir()
 	contents := []byte("contents")
 	ctx := context.Background()
 	for _, storageClass := range s3StorageClasses {
@@ -302,13 +308,9 @@ func TestDelete(t *testing.T) {
 		t.Skip(skipS3())
 	}
 
-	rootDir, err := ioutil.TempDir("", "driver-")
-	if err != nil {
-		t.Fatalf("unexpected error creating temporary directory: %v", err)
-	}
-	defer os.Remove(rootDir)
+	rootDir := t.TempDir()
 
-	driver, err := s3DriverConstructor(rootDir, s3.StorageClassStandard)
+	drvr, err := s3DriverConstructor(rootDir, s3.StorageClassStandard)
 	if err != nil {
 		t.Fatalf("unexpected error creating driver with standard storage: %v", err)
 	}
@@ -343,7 +345,7 @@ func TestDelete(t *testing.T) {
 		return false
 	}
 
-	var objs = []string{
+	objs := []string{
 		"/file1",
 		"/file1-2",
 		"/file1/2",
@@ -411,40 +413,40 @@ func TestDelete(t *testing.T) {
 	}
 
 	// objects to skip auto-created test case
-	var skipCase = map[string]bool{
+	skipCase := map[string]bool{
 		// special case where deleting "/file1" also deletes "/file1/2" is tested explicitly
 		"/file1": true,
 	}
 	// create a test case for each file
-	for _, path := range objs {
-		if skipCase[path] {
+	for _, p := range objs {
+		if skipCase[p] {
 			continue
 		}
 		tcs = append(tcs, testCase{
-			name:     fmt.Sprintf("delete path:'%s'", path),
-			delete:   path,
-			expected: []string{path},
+			name:     fmt.Sprintf("delete path:'%s'", p),
+			delete:   p,
+			expected: []string{p},
 		})
 	}
 
 	init := func() []string {
 		// init file structure matching objs
 		var created []string
-		for _, path := range objs {
-			err := driver.PutContent(context.Background(), path, []byte("content "+path))
+		for _, p := range objs {
+			err := drvr.PutContent(context.Background(), p, []byte("content "+p))
 			if err != nil {
-				fmt.Printf("unable to init file %s: %s\n", path, err)
+				fmt.Printf("unable to init file %s: %s\n", p, err)
 				continue
 			}
-			created = append(created, path)
+			created = append(created, p)
 		}
 		return created
 	}
 
 	cleanup := func(objs []string) {
 		var lastErr error
-		for _, path := range objs {
-			err := driver.Delete(context.Background(), path)
+		for _, p := range objs {
+			err := drvr.Delete(context.Background(), p)
 			if err != nil {
 				switch err.(type) {
 				case storagedriver.PathNotFoundError:
@@ -463,7 +465,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			objs := init()
 
-			err := driver.Delete(context.Background(), tc.delete)
+			err := drvr.Delete(context.Background(), tc.delete)
 
 			if tc.err != nil {
 				if err == nil {
@@ -491,7 +493,7 @@ func TestDelete(t *testing.T) {
 				return false
 			}
 			for _, path := range objs {
-				stat, err := driver.Stat(context.Background(), path)
+				stat, err := drvr.Stat(context.Background(), path)
 				if err != nil {
 					switch err.(type) {
 					case storagedriver.PathNotFoundError:
@@ -525,18 +527,14 @@ func TestWalk(t *testing.T) {
 		t.Skip(skipS3())
 	}
 
-	rootDir, err := ioutil.TempDir("", "driver-")
-	if err != nil {
-		t.Fatalf("unexpected error creating temporary directory: %v", err)
-	}
-	defer os.Remove(rootDir)
+	rootDir := t.TempDir()
 
-	driver, err := s3DriverConstructor(rootDir, s3.StorageClassStandard)
+	drvr, err := s3DriverConstructor(rootDir, s3.StorageClassStandard)
 	if err != nil {
 		t.Fatalf("unexpected error creating driver with standard storage: %v", err)
 	}
 
-	var fileset = []string{
+	fileset := []string{
 		"/file1",
 		"/folder1/file1",
 		"/folder2/file1",
@@ -547,22 +545,22 @@ func TestWalk(t *testing.T) {
 
 	// create file structure matching fileset above
 	var created []string
-	for _, path := range fileset {
-		err := driver.PutContent(context.Background(), path, []byte("content "+path))
+	for _, p := range fileset {
+		err := drvr.PutContent(context.Background(), p, []byte("content "+p))
 		if err != nil {
-			fmt.Printf("unable to create file %s: %s\n", path, err)
+			fmt.Printf("unable to create file %s: %s\n", p, err)
 			continue
 		}
-		created = append(created, path)
+		created = append(created, p)
 	}
 
 	// cleanup
 	defer func() {
 		var lastErr error
-		for _, path := range created {
-			err := driver.Delete(context.Background(), path)
+		for _, p := range created {
+			err := drvr.Delete(context.Background(), p)
 			if err != nil {
-				_ = fmt.Errorf("cleanup failed for path %s: %s", path, err)
+				_ = fmt.Errorf("cleanup failed for path %s: %s", p, err)
 				lastErr = err
 			}
 		}
@@ -664,7 +662,7 @@ func TestWalk(t *testing.T) {
 			tc.from = "/"
 		}
 		t.Run(tc.name, func(t *testing.T) {
-			err := driver.Walk(context.Background(), tc.from, func(fileInfo storagedriver.FileInfo) error {
+			err := drvr.Walk(context.Background(), tc.from, func(fileInfo storagedriver.FileInfo) error {
 				walked = append(walked, fileInfo.Path())
 				return tc.fn(fileInfo)
 			})
@@ -684,12 +682,7 @@ func TestOverThousandBlobs(t *testing.T) {
 		t.Skip(skipS3())
 	}
 
-	rootDir, err := ioutil.TempDir("", "driver-")
-	if err != nil {
-		t.Fatalf("unexpected error creating temporary directory: %v", err)
-	}
-	defer os.Remove(rootDir)
-
+	rootDir := t.TempDir()
 	standardDriver, err := s3DriverConstructor(rootDir, s3.StorageClassStandard)
 	if err != nil {
 		t.Fatalf("unexpected error creating driver with standard storage: %v", err)
@@ -717,12 +710,7 @@ func TestMoveWithMultipartCopy(t *testing.T) {
 		t.Skip(skipS3())
 	}
 
-	rootDir, err := ioutil.TempDir("", "driver-")
-	if err != nil {
-		t.Fatalf("unexpected error creating temporary directory: %v", err)
-	}
-	defer os.Remove(rootDir)
-
+	rootDir := t.TempDir()
 	d, err := s3DriverConstructor(rootDir, s3.StorageClassStandard)
 	if err != nil {
 		t.Fatalf("unexpected error creating driver: %v", err)
@@ -771,12 +759,7 @@ func TestListObjectsV2(t *testing.T) {
 		t.Skip(skipS3())
 	}
 
-	rootDir, err := ioutil.TempDir("", "driver-")
-	if err != nil {
-		t.Fatalf("unexpected error creating temporary directory: %v", err)
-	}
-	defer os.Remove(rootDir)
-
+	rootDir := t.TempDir()
 	d, err := s3DriverConstructor(rootDir, s3.StorageClassStandard)
 	if err != nil {
 		t.Fatalf("unexpected error creating driver: %v", err)
@@ -789,8 +772,8 @@ func TestListObjectsV2(t *testing.T) {
 	for i := 0; i < n; i++ {
 		filePaths = append(filePaths, fmt.Sprintf("%s/%d", prefix, i))
 	}
-	for _, path := range filePaths {
-		if err := d.PutContent(ctx, path, []byte(path)); err != nil {
+	for _, p := range filePaths {
+		if err := d.PutContent(ctx, p, []byte(p)); err != nil {
 			t.Fatalf("unexpected error putting content: %v", err)
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -33,8 +33,6 @@ github.com/Azure/go-autorest/autorest/adal
 # github.com/Azure/go-autorest/autorest/date v0.3.0
 ## explicit; go 1.12
 github.com/Azure/go-autorest/autorest/date
-# github.com/Azure/go-autorest/autorest/to v0.4.0
-## explicit; go 1.12
 # github.com/Azure/go-autorest/logger v0.2.1
 ## explicit; go 1.12
 github.com/Azure/go-autorest/logger
@@ -99,8 +97,6 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/beorn7/perks v1.0.1
 ## explicit; go 1.11
 github.com/beorn7/perks/quantile
-# github.com/bitly/go-simplejson v0.5.0
-## explicit
 # github.com/bshuster-repo/logrus-logstash-hook v1.0.0
 ## explicit
 github.com/bshuster-repo/logrus-logstash-hook
@@ -181,8 +177,6 @@ github.com/distribution/distribution/v3/registry/storage/driver/testsuites
 github.com/distribution/distribution/v3/testutil
 github.com/distribution/distribution/v3/uuid
 github.com/distribution/distribution/v3/version
-# github.com/dnaeon/go-vcr v1.0.1
-## explicit
 # github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
 ## explicit
 github.com/docker/go-events
@@ -262,8 +256,6 @@ github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/mitchellh/mapstructure v1.1.2
 ## explicit
 github.com/mitchellh/mapstructure
-# github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f
-## explicit
 # github.com/ncw/swift v1.0.47
 ## explicit
 github.com/ncw/swift


### PR DESCRIPTION
- Revert "remove v3 from name for discovery"
- UPSTREAM: docker/distribution: 3296: allow pointing to an AWS config file as a parameter for the s3 driver
